### PR TITLE
Changes for compatibility for Java 9/10

### DIFF
--- a/ModelInterface/ConfigurationEditor/utils/DOMUtils.java
+++ b/ModelInterface/ConfigurationEditor/utils/DOMUtils.java
@@ -35,6 +35,7 @@ import java.awt.Container;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.InputStream;
+import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -46,10 +47,9 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import com.sun.org.apache.xml.internal.serialize.OutputFormat;
-import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
-//import org.w3c.dom.ls.DOMImplementationLS;
-//import org.w3c.dom.ls.LSSerializer;
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSSerializer;
 import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -257,43 +257,6 @@ public final class DOMUtils {
 	    }
 
 
-	    if(!aDocument.getDocumentElement().getAttribute("needs-save").equals("true")) {
-		    Logger.global.log(Level.INFO, "Saving an unmodified document. needs-save: " + aDocument.getDocumentElement().getAttribute("needs-save"));
-	    }
-	    aDocument.getDocumentElement().removeAttribute("needs-save"); //$NON-NLS-1$
-
-	    // specify output formating properties
-	    OutputFormat format = new OutputFormat(aDocument);
-	    format.setEncoding("UTF-8");
-	    format.setLineSeparator("\r\n");
-	    format.setIndenting(true);
-	    format.setIndent(3);
-	    format.setLineWidth(0);
-	    format.setPreserveSpace(false);
-	    format.setOmitDocumentType(true);
-
-	    // create the searlizer and have it print the document
-	    try {
-		    final File outputFile = FileUtils.getDocumentFile(aDocument);
-		    assert (outputFile != null);
-		    FileWriter fw = new FileWriter(outputFile);
-		    XMLSerializer serializer = new XMLSerializer(fw, format);
-		    serializer.asDOMSerializer();
-		    serializer.serialize(aDocument);
-		    fw.close();
-	    } catch (java.io.IOException e) {
-		    // Unexpected error creating writing the file. Inform the user
-		    // and log the error.
-		    Logger.global.throwing("DOMUtils", "serialize", e); //$NON-NLS-1$ //$NON-NLS-2$
-		    final String errorMessage = Messages.getString("DOMUtils.22") //$NON-NLS-1$
-			    + e.getMessage() + "."; //$NON-NLS-1$
-		    final String errorTitle = Messages.getString("DOMUtils.24"); //$NON-NLS-1$
-		    JOptionPane.showMessageDialog(aContainer, errorMessage, errorTitle,
-				    JOptionPane.ERROR_MESSAGE);
-		    return false;
-	    }
-
-	    /*
 	    // Create the serializer.
 	    DOMImplementation impl = aDocument.getImplementation();
 	    DOMImplementationLS implLS = (DOMImplementationLS) impl.getFeature("LS","3.0");
@@ -335,7 +298,6 @@ JOptionPane.showMessageDialog(aContainer, errorMessage, errorTitle,
 JOptionPane.ERROR_MESSAGE);
 return false;
 	    }
-	    */
 	    // Add an attribute that signals that the document has been saved
 	    // successfully.
 	    aDocument.getDocumentElement().setAttribute("document-saved", "true");

--- a/ModelInterface/InterfaceMain.java
+++ b/ModelInterface/InterfaceMain.java
@@ -253,6 +253,11 @@ public class InterfaceMain implements ActionListener {
 		if(propertiesFile.exists()) {
 			try {
 				savedProperties.loadFromXML(new FileInputStream(propertiesFile));
+                String prettyPrintProperty = savedProperties.getProperty("pretty-print", null);
+                if(System.getProperty("ModelInterface.pretty-print", null) == null && prettyPrintProperty != null) {
+                    System.getProperties().setProperty("ModelInterface.pretty-print", prettyPrintProperty);
+                }
+
 			} catch (FileNotFoundException notFound) {
 				// well I checked if it existed before so..
 			} catch (IOException ioe) {

--- a/ModelInterface/ModelGUI2/DbViewer.java
+++ b/ModelInterface/ModelGUI2/DbViewer.java
@@ -89,8 +89,6 @@ import java.awt.Cursor;
 import java.awt.event.MouseAdapter;
 import java.util.*;
 
-import com.sun.org.apache.xml.internal.serialize.OutputFormat;
-import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -102,6 +100,7 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Element;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
+import org.w3c.dom.DOMConfiguration;
 import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -1376,25 +1375,17 @@ public class DbViewer implements ActionListener, MenuAdder, BatchRunner {
 	}
 
 	public boolean writeFile(File file, Document theDoc) {
+        LSSerializer serializer = implls.createLSSerializer();
 		// specify output formating properties
-		OutputFormat format = new OutputFormat(theDoc);
-		format.setEncoding("UTF-8");
-		format.setLineSeparator("\r\n");
-		format.setIndenting(true);
-		format.setIndent(3);
-		format.setLineWidth(0);
-		format.setPreserveSpace(false);
-		format.setOmitDocumentType(true);
+        DOMConfiguration domConfig = serializer.getDomConfig();
+        boolean prettyPrint = Boolean.parseBoolean(System.getProperty("ModelInterface.pretty-print", "true"));
+        domConfig.setParameter("format-pretty-print", prettyPrint);
 
 		// create the searlizer and have it print the document
 
 		try {
-			FileWriter fw = new FileWriter(file);
-			XMLSerializer serializer = new XMLSerializer(fw, format);
-			serializer.asDOMSerializer();
-			serializer.serialize(theDoc);
-			fw.close();
-		} catch (java.io.IOException e) {
+            serializer.writeToURI(theDoc, file.toURI().toString());
+		} catch (LSException e) {
 			System.err.println("Error outputing tree: " + e);
 			return false;
 		}

--- a/ModelInterface/ModelGUI2/InputViewer.java
+++ b/ModelInterface/ModelGUI2/InputViewer.java
@@ -32,8 +32,6 @@ package ModelInterface.ModelGUI2;
 import org.w3c.dom.*;
 import org.w3c.dom.ls.*;
 import org.w3c.dom.bootstrap.*;
-import com.sun.org.apache.xml.internal.serialize.OutputFormat;
-import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
 import org.jfree.chart.JFreeChart;
 
 import javax.xml.xpath.*;
@@ -1269,25 +1267,17 @@ public class InputViewer implements ActionListener, TableModelListener, MenuAdde
 	 * @return whether the file was actually written or not
 	 */
 	public boolean writeFile(File file, Document theDoc) {
+        LSSerializer serializer = implls.createLSSerializer();
 		// specify output formating properties
-		OutputFormat format = new OutputFormat(theDoc);
-		format.setEncoding("UTF-8");
-		format.setLineSeparator("\r\n");
-		format.setIndenting(true);
-		format.setIndent(3);
-		format.setLineWidth(0);
-		format.setPreserveSpace(false);
-		format.setOmitDocumentType(true);
+        DOMConfiguration domConfig = serializer.getDomConfig();
+        boolean prettyPrint = Boolean.parseBoolean(System.getProperty("ModelInterface.pretty-print", "true"));
+        domConfig.setParameter("format-pretty-print", prettyPrint);
 
 		// create the searlizer and have it print the document
 
 		try {
-			FileWriter fw = new FileWriter(file);
-			XMLSerializer serializer = new XMLSerializer(fw, format);
-			serializer.asDOMSerializer();
-			serializer.serialize(theDoc);
-			fw.close();
-		} catch (java.io.IOException e) {
+            serializer.writeToURI(theDoc, file.toURI().toString());
+		} catch (LSException e) {
 			System.err.println("Error outputing tree: " + e);
 			return false;
 		}

--- a/ModelInterface/ModelGUI2/QueryTransferHandler.java
+++ b/ModelInterface/ModelGUI2/QueryTransferHandler.java
@@ -33,6 +33,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.Element;
 import org.w3c.dom.DOMException;
+import org.w3c.dom.DOMConfiguration;
 import org.w3c.dom.ls.*;
 
 import java.awt.datatransfer.DataFlavor;
@@ -340,7 +341,14 @@ public class QueryTransferHandler extends TransferHandler {
 					}
 				}
 				if(flavor.isFlavorTextType()) {
-					return implls.createLSSerializer().writeToString(toSerialize);
+                    LSSerializer serializer = implls.createLSSerializer();
+                    // specify output formating properties
+                    DOMConfiguration domConfig = serializer.getDomConfig();
+                    boolean prettyPrint = Boolean.parseBoolean(System.getProperty("ModelInterface.pretty-print", "true"));
+                    domConfig.setParameter("format-pretty-print", prettyPrint);
+                    // always skip the XML decleration for copy/paste
+                    domConfig.setParameter("xml-declaration", false);
+					return serializer.writeToString(toSerialize);
 				} else {
 					return toSerialize;
 				}

--- a/ModelInterface/ModelGUI2/queries/QueryGenerator.java
+++ b/ModelInterface/ModelGUI2/queries/QueryGenerator.java
@@ -705,7 +705,7 @@ public class QueryGenerator implements java.io.Serializable{
 		temp.appendChild(!isRunFunction ? doc.createTextNode(xPath) : doc.createCDATASection(xPath));
 		queryNode.appendChild(temp);
 		temp = doc.createElement("comments");
-		temp.appendChild(doc.createTextNode(comments));
+		temp.appendChild(doc.createTextNode(comments != null ? comments : ""));
 		queryNode.appendChild(temp);
 		if(labelRewriteMap != null) {
 			temp = doc.createElement("labelRewriteList");


### PR DESCRIPTION
Remove use of XMLSerializer class which was an internal API and it's use
is no longer allowed since Java 9.

Instead we will fall back to the Load/Store XML API which doesn't
provide as much flexibility.  The resulting XML files will therefore
differ in terms of whitespace generated.

I've added a new property boolean "pretty-print" (or via System property
"ModelInterface.pretty-print") to control of serialized XML from the
Model Interface will be pretty printed.