### PR TITLE
Fix bug when runing queries through RunMIFunction (rgcam) results that

### DIFF
--- a/ModelInterface/ModelGUI2/xmldb/RunMIQuery.java
+++ b/ModelInterface/ModelGUI2/xmldb/RunMIQuery.java
@@ -155,7 +155,8 @@ public class RunMIQuery extends QueryModule {
                 parentPath.offerLast(unitsRow);
                 unitsRow.key = "Units";
             }
-            parentPath.peekLast().value = XMLDB.getAttrMap(BXNode.get(tempNode.parent())).get("unit");
+            String currUnits = XMLDB.getAttrMap(BXNode.get(tempNode.parent())).get("unit");
+            parentPath.peekLast().value = currUnits == null ? "None Specified" : currUnits;
 
             FElem row = new FElem("record");
             boolean skip = false;


### PR DESCRIPTION
did not set Units were crashing instead of getting reported as "None
Specified"