### PR TITLE
Avoid the convenience method LSSerializer.writeToURI

### DIFF
--- a/ModelInterface/ModelGUI2/DbViewer.java
+++ b/ModelInterface/ModelGUI2/DbViewer.java
@@ -1384,8 +1384,10 @@ public class DbViewer implements ActionListener, MenuAdder, BatchRunner {
 		// create the searlizer and have it print the document
 
 		try {
-            serializer.writeToURI(theDoc, file.toURI().toString());
-		} catch (LSException e) {
+            LSOutput lsOut = implls.createLSOutput();
+            lsOut.setByteStream(new FileOutputStream(file));
+            serializer.write(theDoc, lsOut);
+		} catch (Exception e) {
 			System.err.println("Error outputing tree: " + e);
 			return false;
 		}

--- a/ModelInterface/ModelGUI2/InputViewer.java
+++ b/ModelInterface/ModelGUI2/InputViewer.java
@@ -1276,8 +1276,10 @@ public class InputViewer implements ActionListener, TableModelListener, MenuAdde
 		// create the searlizer and have it print the document
 
 		try {
-            serializer.writeToURI(theDoc, file.toURI().toString());
-		} catch (LSException e) {
+            LSOutput lsOut = implls.createLSOutput();
+            lsOut.setByteStream(new FileOutputStream(file));
+            serializer.write(theDoc, lsOut);
+		} catch (Exception e) {
 			System.err.println("Error outputing tree: " + e);
 			return false;
 		}

--- a/ModelInterface/ModelGUI2/csvconv/CSVToXMLMain.java
+++ b/ModelInterface/ModelGUI2/csvconv/CSVToXMLMain.java
@@ -36,6 +36,7 @@ import java.io.FileInputStream;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.FileWriter;
+import java.io.FileOutputStream;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -310,6 +311,8 @@ public class CSVToXMLMain {
 			.newInstance();
         DOMImplementationLS implls = (DOMImplementationLS)reg.getDOMImplementation("XML 3.0");
         LSSerializer serializer = implls.createLSSerializer();
+        LSOutput lsOut = implls.createLSOutput();
+        lsOut.setByteStream(new FileOutputStream(file));
 		// specify output formating properties
         DOMConfiguration domConfig = serializer.getDomConfig();
         boolean prettyPrint = Boolean.parseBoolean(System.getProperty("ModelInterface.pretty-print", "true"));
@@ -317,7 +320,7 @@ public class CSVToXMLMain {
 
 		// create the searlizer and have it print the document
 
-            serializer.writeToURI(theDoc, file.toURI().toString());
+            serializer.write(theDoc, lsOut);
 		} catch (Exception e) {
 			System.err.println("Error outputing tree: " + e);
 			return false;


### PR DESCRIPTION
Which seems to break in Java 12.  Instead fall back to explicitly creating/setup an LSOutput object and use LSSerializer.write instead.