### PR TITLE
Basex 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 # Java compiler options to target specific JVM versions to allow
 # backwards compatibility.
-JAVA_TARGET = -target 1.7 -source 1.7
+JAVA_TARGET = -target 1.8 -source 1.8
 
 ifeq ($(strip $(BUILD_DIR)),)
 	BUILD_DIR = ./

--- a/ModelInterface/ModelGUI2/queries/CostCurveQueryBuilder.java
+++ b/ModelInterface/ModelGUI2/queries/CostCurveQueryBuilder.java
@@ -404,7 +404,7 @@ public class CostCurveQueryBuilder extends QueryBuilder {
 		if(!setNodeLevel && !setYearLevel && !attrMap.isEmpty()) {
             // TODO: add the ability to use showAttrMap
 			String attr = XMLDB.getAllAttr(attrMap, showAttrList);
-            if(attr != "") {
+            if(!attr.equals("")) {
                 currRow.key = nodeName;
                 currRow.value = attr;
             }

--- a/ModelInterface/ModelGUI2/queries/CostCurveQueryBuilder.java
+++ b/ModelInterface/ModelGUI2/queries/CostCurveQueryBuilder.java
@@ -410,7 +410,7 @@ public class CostCurveQueryBuilder extends QueryBuilder {
             }
         }
         ANode parentNode = currNode.parent();
-		if(parentNode.nodeType() != NodeType.DOC) {
+		if(parentNode.nodeType() != NodeType.DOCUMENT_NODE) {
             // recursively process parents
             addToDataTree(parentNode, parentPath, isGlobal);
         } else {

--- a/ModelInterface/ModelGUI2/queries/CostCurveQueryBuilder.java
+++ b/ModelInterface/ModelGUI2/queries/CostCurveQueryBuilder.java
@@ -31,6 +31,7 @@ package ModelInterface.ModelGUI2.queries;
 
 import ModelInterface.ModelGUI2.xmldb.XMLDB;
 import ModelInterface.common.DataPair;
+import ModelInterface.ModelGUI2.xmldb.QueryRow;
 
 import javax.swing.JList;
 import javax.swing.JButton;
@@ -40,6 +41,7 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.ListSelectionModel;
 
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Iterator;
@@ -50,6 +52,7 @@ import java.util.TreeMap;
 import java.util.EventListener;
 
 import org.basex.query.value.node.ANode;
+import org.basex.query.value.type.NodeType;
 import org.basex.api.dom.BXNode;
 import org.basex.api.dom.BXElem;
 
@@ -324,4 +327,105 @@ public class CostCurveQueryBuilder extends QueryBuilder {
 		} 
 		return tempMap;
 	}
+	public void addToDataTree(ANode currNode, ListIterator<QueryRow> parentPath, boolean isGlobal) throws Exception {
+        QueryRow currRow = null;
+        if(parentPath.hasNext()) {
+            currRow = parentPath.next();
+            if(currRow.id != null && currRow.id.is(currNode)) {
+                // The rest of this path is the same as the last node proccessed.
+                return;
+            } else {
+                currRow = new QueryRow(currNode);
+                parentPath.set(currRow);
+            }
+        } else {
+            currRow = new QueryRow(currNode);
+            parentPath.add(currRow);
+        }
+        BXNode currDOM = BXNode.get(currNode);
+
+		// cache node properties since these may need to go back to the database which could
+		// be expensive
+		String nodeName = currDOM.getNodeName();
+		// run functions can not utilize an attribute map cache since they rely on getNodeHandle
+		// which is not available in those kinds of queries
+		Map<String, String> attrMap = XMLDB.getAttrMapWithCache(currDOM);
+
+		// set the type as the node name if it does not have a type attribute
+		String type = attrMap.get("type");
+		if(type == null) {
+			type = nodeName;
+		}
+
+		// try to find the axis values at the current node
+		boolean setNodeLevel = false;
+		boolean setYearLevel = false;
+		if(nodeName.equals(qg.nodeLevel.getKey())) {
+			setNodeLevel = true;
+            currRow.key = qg.axis1Name;
+			if(qg.nodeLevel.getKey().equals("UndiscountedCost") || qg.nodeLevel.getKey().equals("DiscountedCost")) {
+				if(isGlobal) {
+					currRow.value = "Global";
+				} else {
+					currRow.value = attrMap.get("name");
+				}
+			} else if(isGlobal) {
+                currRow.value = "Global";
+			} else {
+                currRow.value = currDOM.getFirstChild().getFirstChild().getNodeValue();
+			}
+
+		}
+		if(nodeName.equals(qg.yearLevel.getKey())) {
+			setYearLevel = true;
+            if(setNodeLevel) {
+                currRow = new QueryRow(currNode);
+                if(parentPath.hasNext()) {
+                    parentPath.next();
+                    parentPath.set(currRow);
+                } else {
+                    parentPath.add(currRow);
+                }
+            }
+            currRow.key = qg.axis2Name;
+			if(qg.nodeLevel.getKey().equals("UndiscountedCost") || qg.nodeLevel.getKey().equals("DiscountedCost")) {
+                currRow.value = qg.nodeLevel.getKey();
+		} else {
+            if(qg.axis2Name.equals("Year")) {
+                currRow.value = currDOM.getFirstChild().getFirstChild().getNodeValue();
+            } else {
+                currRow.value = currDOM.getFirstChild().getNextSibling().getFirstChild().getNodeValue();
+            }
+		}
+
+		}
+		// if we should not collapse this node then pick out the attributes which
+		// check if we need to collapse this level
+		if(!setNodeLevel && !setYearLevel && !attrMap.isEmpty()) {
+            // TODO: add the ability to use showAttrMap
+			String attr = XMLDB.getAllAttr(attrMap, showAttrList);
+            if(attr != "") {
+                currRow.key = nodeName;
+                currRow.value = attr;
+            }
+        }
+        ANode parentNode = currNode.parent();
+		if(parentNode.nodeType() != NodeType.DOC) {
+            // recursively process parents
+            addToDataTree(parentNode, parentPath, isGlobal);
+        } else {
+            // We are at the top of the nesting and the stop point for recursion
+            // Generally there is nothing more to do however we need to correct
+            // for the special case there the distance from a query result to the
+            // top changes (the length of parentPath is changing).  We need to ensure
+            // there are no more items left on the list (except for Units).  This
+            // situation is not ideal as it defeats out caching strategy.
+            while(parentPath.hasNext()) {
+                QueryRow extraRow = parentPath.next();
+                if(extraRow.key == null || !extraRow.key.equals("Units")) {
+                    parentPath.remove();
+                }
+            }
+        }
+    }
 }

--- a/ModelInterface/ModelGUI2/queries/QueryBuilder.java
+++ b/ModelInterface/ModelGUI2/queries/QueryBuilder.java
@@ -30,6 +30,7 @@
 package ModelInterface.ModelGUI2.queries;
 
 import ModelInterface.common.DataPair;
+import ModelInterface.ModelGUI2.xmldb.QueryRow;
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -38,6 +39,7 @@ import java.util.Map;
 import java.util.Vector;
 import java.util.EventListener;
 import java.util.List;
+import java.util.ListIterator;
 
 public abstract class QueryBuilder implements java.io.Serializable {
 
@@ -90,4 +92,7 @@ public abstract class QueryBuilder implements java.io.Serializable {
 	public Map addToDataTree(ANode currNode, Map dataTree, DataPair<String, String> axisValue, boolean isGlobal) throws Exception {
 		return qg.defaultAddToDataTree(currNode, dataTree, axisValue, isGlobal);
 	}
+	public void addToDataTree(ANode currNode, ListIterator<QueryRow> parentPath, boolean isGlobal) throws Exception {
+        qg.defaultAddToDataTree(currNode, parentPath, isGlobal);
+    }
 }

--- a/ModelInterface/ModelGUI2/queries/QueryGenerator.java
+++ b/ModelInterface/ModelGUI2/queries/QueryGenerator.java
@@ -883,6 +883,13 @@ public class QueryGenerator implements java.io.Serializable{
         }
 		return tempMap;
 	}
+	public void addToDataTree(ANode currNode, ListIterator<QueryRow> parentPath, boolean isGlobal) throws Exception {
+		if(qb != null) {
+			qb.addToDataTree(currNode, parentPath, isGlobal);
+		} else {
+			defaultAddToDataTree(currNode, parentPath, isGlobal);
+		}
+    }
 	public void defaultAddToDataTree(ANode currNode, ListIterator<QueryRow> parentPath, boolean isGlobal) throws Exception {
         QueryRow currRow = null;
         if(parentPath.hasNext()) {

--- a/ModelInterface/ModelGUI2/queries/QueryGenerator.java
+++ b/ModelInterface/ModelGUI2/queries/QueryGenerator.java
@@ -979,7 +979,7 @@ public class QueryGenerator implements java.io.Serializable{
             }
         }
         ANode parentNode = currNode.parent();
-		if(parentNode.nodeType() != NodeType.DOC) {
+		if(parentNode.nodeType() != NodeType.DOCUMENT_NODE) {
             // recursively process parents
             defaultAddToDataTree(parentNode, parentPath, isGlobal);
         } else {

--- a/ModelInterface/ModelGUI2/xmldb/RunMIQuery.java
+++ b/ModelInterface/ModelGUI2/xmldb/RunMIQuery.java
@@ -120,7 +120,8 @@ public class RunMIQuery extends QueryModule {
                 throw new Exception("Could not find scenarios to run.");
             }
             QueryProcessor queryProc = xmldb.createQuery(qg, scenariosToRun.toArray(), regions);
-            return buildTable(queryProc, qg);
+            boolean isGlobal = regions.length > 0 ? regions[0].equals("Global") : false;
+            return buildTable(queryProc, qg, isGlobal);
         } catch(Exception e) {
             e.printStackTrace();
             throw new QueryException(e);
@@ -133,12 +134,11 @@ public class RunMIQuery extends QueryModule {
             System.setErr(stderr);
         }
     }
-    private Map buildTable(QueryProcessor queryProc, QueryGenerator qg) throws Exception {
+    private Map buildTable(QueryProcessor queryProc, QueryGenerator qg, boolean isGlobal) throws Exception {
         System.out.println("In Function: "+System.currentTimeMillis());
         // TODO: replicate these checks, currently just assuming they are all false
         boolean sumAll = false;
         boolean isTotal = false;
-        boolean isGlobal = false;
 
         Map output = Map.EMPTY;
         ValueBuilder records = new ValueBuilder(queryContext);
@@ -150,7 +150,7 @@ public class RunMIQuery extends QueryModule {
         boolean isFirstRow = true;
         while((tempNode = (ANode)res.next()) != null) {
             BXNode domNode = BXNode.get(tempNode);
-            qg.defaultAddToDataTree(tempNode.parent(), parentPath.listIterator(0), isGlobal);
+            qg.addToDataTree(tempNode.parent(), parentPath.listIterator(0), isGlobal);
 
             if(!parentPath.peekLast().key.equals("Units")) {
                 QueryRow unitsRow = new QueryRow(null);

--- a/ModelInterface/ModelGUI2/xmldb/RunMIQuery.java
+++ b/ModelInterface/ModelGUI2/xmldb/RunMIQuery.java
@@ -43,11 +43,11 @@ import org.basex.query.*;
 import org.basex.query.iter.Iter;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
-import org.basex.query.value.array.Array;
+import org.basex.query.value.array.XQArray;
 import org.basex.query.value.seq.StrSeq;
 import org.basex.query.value.seq.Empty;
 import org.basex.query.value.node.*;
-import org.basex.query.value.map.Map;
+import org.basex.query.value.map.XQMap;
 import org.basex.api.dom.BXNode;
 import org.basex.util.list.StringList;
 
@@ -134,13 +134,13 @@ public class RunMIQuery extends QueryModule {
             System.setErr(stderr);
         }
     }
-    private Map buildTable(QueryProcessor queryProc, QueryGenerator qg, boolean isGlobal) throws Exception {
+    private XQMap buildTable(QueryProcessor queryProc, QueryGenerator qg, boolean isGlobal) throws Exception {
         System.out.println("In Function: "+System.currentTimeMillis());
         // TODO: replicate these checks, currently just assuming they are all false
         boolean sumAll = false;
         boolean isTotal = false;
 
-        Map output = Map.EMPTY;
+        XQMap output = XQMap.EMPTY;
         ValueBuilder records = new ValueBuilder(queryContext);
         Iter res = queryProc.iter();
         ANode tempNode;
@@ -186,12 +186,12 @@ public class RunMIQuery extends QueryModule {
             }
             if(!skip) {
                 row[colIndex] = Str.get(domNode.getNodeValue());
-                records.add(Array.from(row));
+                records.add(XQArray.from(row));
             }
         }
         // the xquery wants the header as an array under the "names" key
         output = output.put(Str.get("names"),
-                Array.from(header.toArray(new Value[0])),
+                XQArray.from(header.toArray(new Value[0])),
                 queryContext.root.info);
         // and it wants the data as a sequence of arrays under the "records" key
         output = output.put(Str.get("records"),

--- a/ModelInterface/ModelGUI2/xmldb/RunMIQuery.java
+++ b/ModelInterface/ModelGUI2/xmldb/RunMIQuery.java
@@ -181,7 +181,7 @@ public class RunMIQuery extends QueryModule {
                     // skip this data since a rewrite list set the value
                     // to an empty string indicating the user wanted to
                     // delete it
-                    skip = skip || currRow.value.equals("");
+                    skip = skip || (!currRow.key.equals("Units") && currRow.value.equals(""));
                 }
             }
             if(!skip) {

--- a/ModelInterface/ModelGUI2/xmldb/XMLDB.java
+++ b/ModelInterface/ModelGUI2/xmldb/XMLDB.java
@@ -61,6 +61,7 @@ import org.basex.query.value.node.ANode;
 import org.basex.query.value.node.DBNode;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
+import org.basex.io.IOFile;
 import org.basex.io.out.PrintOutput;
 import org.basex.io.serial.Serializer;
 
@@ -249,7 +250,7 @@ public class XMLDB {
                 System.err.println(aDocName+" matched "+docPre.length+" docs; != 1");
                 return false;
             }
-            final PrintOutput out = new PrintOutput(aLocation.getPath());
+            final PrintOutput out = new PrintOutput(new IOFile(aLocation));
             final Serializer outputter = Serializer.get(out);
             outputter.serialize(new DBNode(context.data(), docPre[0]));
             outputter.close();


### PR DESCRIPTION
API changes to work with BaseX 9.

Change the RunMIQuery BaseX plugin (used in rgcam/gcam_reader) to output using the new "xquery" format instead of XML which saves a LOT of memory when serializing large results.

Make sure we can do Cost Calculator queries from RunMIQuery (for rgcam/gcam_reader) which means we need to allow specializations for the `addToDataTree` method.